### PR TITLE
Added option to avoid caching of results when calling listdir.

### DIFF
--- a/vos/vos.py
+++ b/vos/vos.py
@@ -1339,17 +1339,19 @@ class Client:
             infoList[node.name] = node.getInfo()
         return infoList.items()
 
-
-    def listdir(self, uri):
-        """Walk through the directory structure a al os.walk"""
+    def listdir(self, uri, force=False):
+        """
+        Walk through the directory structure a al os.walk.
+        Setting force=True will make sure no caching of results are used.
+        """
         #logging.debug("getting a listing of %s " % ( uri))
         names = []
         logging.debug(str(uri))
-        node = self.getNode(uri, limit=None)
+        node = self.getNode(uri, limit=None, force=force)
         while node.type == "vos:LinkNode":
             uri = node.target
             # logging.debug(uri)
-            node = self.getNode(uri, limit=None)
+            node = self.getNode(uri, limit=None, force=force)
         for thisNode in node.getNodeList():
             names.append(thisNode.name)
         return names


### PR DESCRIPTION
Added optional parameter 'force' to vos.Client.listdir.  This is passed along to getNode.  The end effect is that if force is set to True then cached results will not be used for the listing.
