### PR TITLE
Random access

### DIFF
--- a/vos/vofs.py
+++ b/vos/vofs.py
@@ -100,7 +100,7 @@ class MyIOProxy(IOProxy):
                     # to client
                     self.lastVOFile = self.vofs.client.open(
                             self.cacheFile.path, mode=os.O_RDONLY, view="data",
-                            size=size, range=range, fullNegotiation=True)
+                            size=size, range=range, full_negotiation=True)
                     buff = self.lastVOFile.read(blockSize)
 
                 if buff is None:

--- a/vos/vos.py
+++ b/vos/vos.py
@@ -1056,22 +1056,22 @@ class Client:
 
 
     def getNodeURL(self, uri, method='GET', view=None, limit=0, nextURI=None, cutout=None,
-                   fullNegotiation=None):
+                   full_negotiation=None):
         """Split apart the node string into parts and return the correct URL for this node"""
         uri = self.fixURI(uri)
 
         # We can force a full negotiation
-        if fullNegotiation:
-            doShortcut = False;
+        if full_negotiation:
+            do_shortcut = False;
         else:
-            doShortcut = self.cadc_short_cut
+            do_shortcut = self.cadc_short_cut
 
-        logger.debug("doShortcut=%i method=%s view=%s" %(doShortcut, method, view) )
+        logger.debug("do_shortcut=%i method=%s view=%s" %(do_shortcut, method, view) )
 
-        if not doShortcut and method == 'GET' and view == 'data':
+        if not do_shortcut and method == 'GET' and view == 'data':
             return self._get(uri)
 
-        if not doShortcut and method in ('PUT'):
+        if not do_shortcut and method in ('PUT'):
             # logger.debug("Using _put")
             return self._put(uri)
 
@@ -1089,9 +1089,9 @@ class Client:
             return uri
         logger.debug("Node URI: %s, server: %s, parts: %s " %( uri, server, str(parts)))
         URL = None
-        if doShortcut and ((method == 'GET' and view in ['data', 'cutout']) or method == "PUT") :
+        if do_shortcut and ((method == 'GET' and view in ['data', 'cutout']) or method == "PUT") :
 
-            ## only get here if doShortcut == True
+            ## only get here if do_shortcut == True
             # find out the URL to the CADC data server
 
             direction = {'GET': 'pullFromVoSpace', 'PUT': 'pushToVoSpace'}
@@ -1284,7 +1284,7 @@ class Client:
 
 
     def open(self, uri, mode=os.O_RDONLY, view=None, head=False, URL=None, 
-            limit=None, nextURI=None, size=None, cutout=None, range=None, fullNegotiation=None):
+            limit=None, nextURI=None, size=None, cutout=None, range=None, full_negotiation=None):
         """Connect to the uri as a VOFile object"""
 
         ### sometimes this is called with mode from ['w', 'r']
@@ -1313,7 +1313,7 @@ class Client:
             raise IOError(errno.EOPNOTSUPP, "Invalid access mode", mode)
         if URL is None:
             ### we where given one, see if getNodeURL can figure this out.
-            URL = self.getNodeURL(uri, method=method, view=view, limit=limit, nextURI=nextURI, cutout=cutout, fullNegotiation=fullNegotiation)
+            URL = self.getNodeURL(uri, method=method, view=view, limit=limit, nextURI=nextURI, cutout=cutout, full_negotiation=full_negotiation)
         if URL is None:
             ## Dang... getNodeURL failed... maybe this is a LinkNode?
             ## if this is a LinkNode then maybe there is a Node.TARGET I could try instead...


### PR DESCRIPTION
Here I have attempted to turn-on the short cut method of obtaining URLs to nodes, using the full negotiation (URL list) method as a fall back.

Some things to note:
- cutouts had some old hard-wired URL code in getNodeURL which I have removed upon JJ's recommendation.
-  when getNodeURL applies the short cut method, I raise an IOError if the response is a 404. Norm mentioned to me that this part of the code looked strange, and he thought that the short cut would involve a GET rather than a POST, so perhaps this should be reviewed.
- if the short cut method produces an unusable URL, the call to self.lastVOFile.read() after the try: should raise an exception. It will then re-try forcing the full negotiation, and the subsequent read() ought to cycle through all of the available URLs.
- although not implemented yet, it might make sense in this final case to remove the URL that failed with the short cut method from the URL list using the full negotiation if it is present.
- there isn't an integration test for cutouts...
