### PR TITLE
S1543

### DIFF
--- a/vos/vos.py
+++ b/vos/vos.py
@@ -1296,7 +1296,7 @@ class Client:
 
 
     def open(self, uri, mode=os.O_RDONLY, view=None, head=False, URL=None,
-             limit=None, nextURI=None, size=None, range=None, cutout=None):
+             limit=None, nextURI=None, size=None, cutout=None, range=None):
         """Connect to the uri as a VOFile object"""
 
         ### sometimes this is called with mode from ['w', 'r']
@@ -1344,7 +1344,7 @@ class Client:
                     # TODO
                     # the above re.search should use generic VOSpace uri search, not CADC specific.
                     ## Since this is an CADC vospace link, just follow it.
-                    return self.open(target, mode, view, head, URL, limit, nextURI, size, cutout)
+                    return self.open(target, mode, view, head, URL, limit, nextURI, size, cutout, range)
                 else:
                     # A target external to VOSpace, open the target directly
                     # TODO


### PR DESCRIPTION
I just tried remote_access after the merge, and it's broken. I should have checked before sending my acceptance request email.

I've pushed one patch to this pull request to fix up a merge conflict. However, there is another more serious one. Currently I see errors in vofs.py at line 85 where it is calling the Client.open() method in vos.py. At commit 2cd3e20506e07c191c6f8c7bf85bf1721f2c4bfd both the "range" and "full_negotiation" keywords were dropped from the interface. It's not clear to me whether line 85 in vofs.py needs to be altered, or "range" added back in to Client.open()
