### PR TITLE
make the setup.py handle new scripts automatically, removed distribute and setuptools 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,30 @@
 
-# Use "distribute"
-from setuptools import setup, find_packages
+from distutils.core import setup
 import sys
+import os
+from vos.__version__ import version
 
 if sys.version_info[0] > 2:
     print 'The caom2 package is only compatible with Python version 2.n'
     sys.exit(-1)
 
+## Build the list of scripts to be installed.
+script_dir = 'scripts'
+scripts = []
+for script in os.listdir(script_dir):
+    if script[-1] in [ "~", "#"]:
+        continue
+    scripts.append(os.path.join(script_dir,script))
 
-from vos.__version__ import version
+
 setup(name="vos",
       version=version,
       url="https://github.com/ijiraq/cadcVOFS",
       description="Tools for interacting with CADC VOSpace.",
-      author="JJ Kavelaars",
-      author_email="jj.kavelaars@nrc.gc.ca",
+      author="JJ Kavelaars, Norm Hill, Adrian Demain, Ed Chapin and others",
+      author_email="jj.kavelaars@nrc-cnrc.gc.ca",
       packages=['vos'],
-      install_requires=['distribute'],
-      scripts=['scripts/getCert','scripts/vsync','scripts/vmv','scripts/vcp','scripts/vrm','scripts/vls','scripts/vmkdir','scripts/mountvofs','scripts/vrmdir', 'scripts/vln', 'scripts/vcat', 'scripts/vtag', 'scripts/vchmod', 'scripts/checkJobPhase', 'scripts/vlock', 'cantop' ],
+      scripts=scripts,
       classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
@NormanHill please accept/merge this pull request.  This is branch-to-branch pull request, which we could start using as a cleaner approach to package development? 

Story:  The setup.py script was written when we had a less clear idea of how to do this.  Distribute has now ended (development moved to disutils2 which is now also stalled). setuptools is a heavy solution for our light-weight package.  Moving back to disutils will make this package easy for users to install as distutils is part of the core python. 
