### PR TITLE
Code change to address infinite loop on copy

### DIFF
--- a/vos/vos.py
+++ b/vos/vos.py
@@ -1019,7 +1019,12 @@ class Client:
                 destSize += len(buf)
         except IOError as e:
             logger.debug(str(e))
-            return self.copy(src, dest, sendMD5=sendMD5)
+            if (srcNode.uri in self.nodeCache):
+                # remove from cache and retry
+                with self.nodeCache.volatile(srcNode.uri):
+                    return self.copy(src, dest, sendMD5=sendMD5)
+            else:
+                raise
         finally:
             fout.close()
             fin.close()


### PR DESCRIPTION
The code change breaks up the tail recursion on Client.copy(...) which loops indefinitely when the target of an externally linked node does not exist.
