### PR TITLE
T64562: fix Content-Length bug

### DIFF
--- a/test/scripts/vospace-mountvospace-atest.tcsh
+++ b/test/scripts/vospace-mountvospace-atest.tcsh
@@ -9,7 +9,7 @@ else
     endif
 endif
 
-set HEADCMD = 'head -c 1'
+set TAILCMD = 'tail -c 1'
 
 if ( `uname -s` == "Darwin" ) then
      set STATCMD = 'stat -f %z'
@@ -231,7 +231,7 @@ foreach pythonVersion ($CADC_PYTHON_TEST_TARGETS)
     ${UMOUNTCMD} $MOUNTPOINT >& /dev/null || echo " [FAIL]" && exit-1
    echo " [OK]"
 
-    # --- test head on a really big file ---
+    # --- test tail on a really big file ---
 
     echo -n "mount vospace static data location readonly "
     $MOUNTCMD $CERT --readonly --vospace="$STATIC" --mountpoint=$MOUNTPOINT --cache_dir=$VOS_CACHE --log=$LOGFILE -d >& /dev/null || echo " [FAIL]" && exit -1
@@ -239,8 +239,8 @@ foreach pythonVersion ($CADC_PYTHON_TEST_TARGETS)
     ls $MOUNTPOINT >& /dev/null || echo [FAIL] && exit -1
     echo " [OK]"
 
-    echo -n "head request on a large file "
-    $HEADCMD $MOUNTPOINT/$BIGSTATICFILE >& /dev/null || echo " [FAIL]" && exit -1
+    echo -n "tail request on a large file "
+    $TAILCMD $MOUNTPOINT/$BIGSTATICFILE >& /dev/null || echo " [FAIL]" && exit -1
     echo " [OK]"
 
     echo -n "unmount vospace"

--- a/vos/vos.py
+++ b/vos/vos.py
@@ -769,9 +769,8 @@ class VOFile:
         # Get the file size. We use this 'X-CADC-Content-Length' as a
         # fallback to work around a server-side Java bug that limits
         # 'Content-Length' to a signed 32-bit integer (~2 gig files)
-        self.size = self.resp.getheader("Content-Length", 0)
-        if int(self.size) == 0:
-            self.size = self.resp.getheader("X-CADC-Content-Length", 0)
+        self.size = self.resp.getheader("Content-Length", self.resp.getheader(
+                "X-CADC-Content-Length",0))
 
         if self.resp.status == 200:
             self.md5sum = self.resp.getheader("Content-MD5", None)


### PR DESCRIPTION
For files with a length larger than a signed 32-bit integer (about 2 gigs) there is a Java bug that results in Content-Length being set to 0. Normally this doesn't cause a problem (e.g., vcp has no problem copying large files). However, vofs needs to know this length, and reading such a large file causes an exception. The first commit is an updated integration test that demonstrates the problem. The second commit uses the accepted workaround of using X_CADC-Content-Length as a fallback.

Question: is something similar needed for puts with vofs?
