### PR TITLE
Added missing content type header in create and mkdir methods

### DIFF
--- a/vos/vos/tests/test_vos.py
+++ b/vos/vos/tests/test_vos.py
@@ -643,7 +643,7 @@ class TestClient(unittest.TestCase):
         node2 = Node(str(node))
         self.assertEqual(node, node2)
         data = str(node)
-        headers = {'size': str(len(data))}
+        headers = {'size': str(len(data)), 'Content-Type': 'text/xml'}
 
         client = Client()
         # client.get_node_url = Mock(return_value='http://foo.com/bar')
@@ -770,6 +770,23 @@ class TestClient(unittest.TestCase):
         client.get_session = Mock(return_value=mock_session)
         client.delete(uri1)
         mock_session.delete.assert_called_once_with(url)
+
+    @patch('vos.vos.net.ws.WsCapabilities.get_access_url',
+           Mock(return_value='http://www.canfar.phys.uvic.ca/vospace/nodes'))
+    def test_mkdir(self):
+        uri = 'vos://create.vospace.auth!vospace/bar'
+        client = Client()
+        node = Node(client.fix_uri(uri), Node.CONTAINER_NODE)
+        headers = {'Content-Type': 'text/xml'}
+
+        client = Client()
+        session_mock = MagicMock()
+        client.get_session = Mock(return_value=session_mock)
+
+        client.mkdir(uri)
+        session_mock.put.assert_called_with(
+            'http://www.canfar.phys.uvic.ca/vospace/nodes/bar',
+            headers=headers, data=str(node))
 
 
 class TestNode(unittest.TestCase):

--- a/vos/vos/vos.py
+++ b/vos/vos/vos.py
@@ -2538,7 +2538,7 @@ class Client(object):
         data = str(node)
         size = len(data)
         return Node(self.get_session(uri).put(
-            url, data=data, headers={'size': str(size)}).content)
+            url, data=data, headers={'size': str(size), 'Content-Type': 'text/xml'}).content)
 
     def update(self, node, recursive=False):
         """Updates the node properties on the server. For non-recursive
@@ -2607,7 +2607,7 @@ class Client(object):
         node = Node(uri, node_type="vos:ContainerNode")
         url = self.get_node_url(uri)
         try:
-            response = self.get_session(uri).put(url, data=str(node))
+            response = self.get_session(uri).put(url, data=str(node), headers={'Content-Type': 'text/xml'})
             response.raise_for_status()
         except HTTPError as http_error:
             if http_error.response.status_code != 409:


### PR DESCRIPTION
Hi,
the methods `create` and `mkdir` aren't providing the Content-Type header. Our VOSpace implementation accepts both XML and JSON (custom, non-standard), so we need the header properly set to perform the content negotiation.

Cheers,
Sonia