### PR TITLE
`vcp` from vospace works when system in readonly mode (CADC 13277)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,6 @@ Note: might need to escape chars in your shell
 ::
 
     cd vos && pip install -e .[test]
-    cd vofs && pip install -e .[test]
 
 Testing packages
 ----------------
@@ -43,14 +42,6 @@ Testing vos
     cd ./vos
     pytest vos
 
-Testing vofs
-~~~~~~~~~~~~
-
-::
-
-    cd ./vofs
-    pytest vofs
-
 
 
 Checkstyle
@@ -60,7 +51,7 @@ not report errors
 
 ::
 
-     flake8 vos/vos vofs/vofs
+     flake8 vos/vos
 
 
 Testing with tox

--- a/vos/test/scripts/vospace-link-atest.tcsh
+++ b/vos/test/scripts/vospace-link-atest.tcsh
@@ -141,20 +141,8 @@ foreach resource ($resources)
       echo " [OK]"
   endif
 
-  echo -n "copy external link"
-  if ( ${?TESTING_CAVERN} ) then
-      echo " [SKIPPED, vos/issues/83]"
-  else
-      rm -f /tmp/e3link
-      $CPCMD $CERT -L $CONTAINER/e3link /tmp/ >& /dev/null || echo " [FAIL]" && exit -1
-      grep -q google /tmp/e3link || echo " [FAIL]" && exit -1
-      rm -f /tmp/e3link
-      echo " [OK]"
-  endif
-
-
   echo -n "Follow the invalid link and fail"
-  $CPCMD $CERT $CONTAINER/e3link/somefile /tmp  >& /dev/null && echo " [FAIL]" && exit -1
+  $CPCMD $CERT $CONTAINER/e3link/somefile /tmp  >& /dev/null && echo " [FAIL]" && exit -
   echo " [OK]"
 
   echo -n "copy file to target through link"

--- a/vos/test/scripts/vospace-lock-atest.tcsh
+++ b/vos/test/scripts/vospace-lock-atest.tcsh
@@ -121,12 +121,10 @@ foreach resource ($resources)
   if ( ${?TESTING_CAVERN} ) then
       echo " [SKIPPED, vos/issues/82]"
   else
-      echo "$LOCKCMD $CERT $CONTAINER $VUNLOCK_ARGS"
       $LOCKCMD $CERT $CONTAINER $VUNLOCK_ARGS > /dev/null || echo " [FAIL]" && exit -1
       echo " [OK]"
       echo -n "check unlocked container "
-      echo "$TAGCMD $CERT $CONTAINER $LIST_ARGS"
-      $TAGCMD $CERT $CONTAINER $LIST_ARGS | grep -q false && set SUCCESS = "true"
+      $TAGCMD $CERT $CONTAINER $LIST_ARGS | grep -q None && set SUCCESS = "true"
 
       if ( ${SUCCESS} == "true" ) then
           set SUCCESS = "false"
@@ -175,7 +173,7 @@ foreach resource ($resources)
       $LOCKCMD $CERT $CONTAINER/target $VUNLOCK_ARGS> /dev/null || echo " [FAIL]" && exit -1
       echo " [OK]"
       echo -n "check unlocked link "
-      $TAGCMD $CERT $CONTAINER/target $LIST_ARGS | grep -q false && set SUCCESS = "true"
+      $TAGCMD $CERT $CONTAINER/target $LIST_ARGS | grep -q None && set SUCCESS = "true"
 
       if ( ${SUCCESS} == "true" ) then
           set SUCCESS = "false"
@@ -226,7 +224,7 @@ foreach resource ($resources)
       $LOCKCMD $CERT $CONTAINER/something.png $VUNLOCK_ARGS> /dev/null || echo " [FAIL]" && exit -1
       echo " [OK]"
       echo -n "check unlocked node "
-      $TAGCMD $CERT $CONTAINER/something.png $LIST_ARGS | grep -q false && set SUCCESS = "true"
+      $TAGCMD $CERT $CONTAINER/something.png $LIST_ARGS | grep -q None && set SUCCESS = "true"
       if ( ${SUCCESS} == "true" ) then
           set SUCCESS = "false"
           echo " [OK]"

--- a/vos/test/scripts/vospace-node-properties.tcsh
+++ b/vos/test/scripts/vospace-node-properties.tcsh
@@ -58,7 +58,7 @@ foreach resource ($resources)
   set TIMESTAMP=`date +%Y-%m-%dT%H-%M-%S`
   set CONTAINER = $BASE/$TIMESTAMP
 
-  echo -n "** checking base URI"
+#  echo -n "** checking base URI"
 #  $RMCMD -R $CERT $BASE > /dev/null
 #  echo -n ", creating base URI"
 #      $MKDIRCMD $CERT $BASE || echo " [FAIL]" && exit -1
@@ -107,24 +107,23 @@ foreach resource ($resources)
   $LSCMD $CERT $CONTAINER | grep ccc | grep -q "drw-------" || echo " [FAIL]" && exit -1
   echo " [OK]"
 
-#  echo -n "test vchmod with recursive option"
-#
-#  $CHMODCMD $CERT -R g+r $CONTAINER $GROUP ||  echo " [FAIL]" && exit -1
-#  echo -n " verify "
-#  $LSCMD $CERT $BASE | grep $TIMESTAMP | grep $GROUP | grep -q "drw-r-----" || echo " [FAIL]" && exit -1
-#  $LSCMD $CERT $CONTAINER | grep aaa | grep $GROUP | grep -q "drw-r-----" || echo " [FAIL]" && exit -1
-#  $LSCMD $CERT $CONTAINER | grep ccc | grep $GROUP | grep -q "drw-r-----" || echo " [FAIL]" && exit -1
-#  $LSCMD $CERT $CONTAINER/aaa | grep bbb | grep $GROUP | grep -q "drw-r-----" || echo " [FAIL]" && exit -1
-#  echo " [OK]"
+  echo -n "test vchmod with recursive option"
+
+  $CHMODCMD $CERT -R g+r $CONTAINER $GROUP ||  echo " [FAIL]" && exit -1
+  echo -n " verify "
+  $LSCMD $CERT $BASE | grep $TIMESTAMP | grep $GROUP | grep -q "drw-r-----" || echo " [FAIL]" && exit -1
+  $LSCMD $CERT $CONTAINER | grep aaa | grep $GROUP | grep -q "drw-r-----" || echo " [FAIL]" && exit -1
+  $LSCMD $CERT $CONTAINER | grep ccc | grep $GROUP | grep -q "drw-r-----" || echo " [FAIL]" && exit -1
+  $LSCMD $CERT $CONTAINER/aaa | grep bbb | grep $GROUP | grep -q "drw-r-----" || echo " [FAIL]" && exit -1
+  echo " [OK]"
 
   echo -n "test vchmod with multiple groups"
 
   set MULTIGROUP = "ABC $GROUP"
-  $CHMODCMD $CERT g+r $CONTAINER/aaa "$MULTIGROUP" ||  echo " [FAIL]" && exit -1
+  $CHMODCMD $CERT g+r $CONTAINER/aaa "$MULTIGROUP" ||  echo " [FAIL1]" && exit -1
   echo -n " verify "
-  $LSCMD $CERT $BASE | grep $TIMESTAMP | grep $GROUP | grep -q "drw-r-----" || echo " [FAIL]" && exit -1
-  echo ""
-  $LSCMD $CERT $CONTAINER | grep aaa | grep "$MULTIGROUP" | grep -q "drw-r-----" || echo " [FAIL]" && exit -1
+  $LSCMD $CERT $BASE | grep $TIMESTAMP | grep $GROUP | grep -q "drw-r-----" || echo " [FAIL2]" && exit -1
+  $LSCMD $CERT $CONTAINER | grep aaa | grep "$MULTIGROUP" | grep -q "drw-r-----" || echo " [FAIL3]" && exit -1
   echo " [OK]"
 
   echo -n "make a sub-container public"
@@ -134,7 +133,7 @@ foreach resource ($resources)
   $LSCMD $CERT $BASE | grep $TIMESTAMP | grep $GROUP | grep -q "drw-r-----" || echo " [FAIL1]" && exit -1
   $LSCMD $CERT $CONTAINER | grep aaa | grep "$MULTIGROUP" | grep -q "drw-r-----" || echo " [FAIL2]" && exit -1
   $LSCMD $CERT $CONTAINER | grep ccc | grep $GROUP | grep -q "drw-r-----" || echo " [FAIL3]" && exit -1
-  $LSCMD $CERT $CONTAINER/aaa | grep bbb | grep "$MULTIGROUP" | grep -q "drw-r--r--" || echo " [FAIL4]" && exit -1
+  $LSCMD $CERT $CONTAINER/aaa | grep bbb | grep "$GROUP" | grep -q "drw-r--r--" || echo " [FAIL4]" && exit -1
   echo " [OK]"
 
 #  echo -n "recursively make all directories public"

--- a/vos/test/scripts_old/vospace-client-atest.tcsh
+++ b/vos/test/scripts_old/vospace-client-atest.tcsh
@@ -78,9 +78,9 @@ foreach resource ($resources)
       echo " [OK]"
   endif
   echo -n "** setting home and base to public, no groups"
-  $CHMODCMD $CERT o+r $VOHOME || echo " [FAIL]" && exit -1
+  $CHMODCMD $CERT o+r $VOHOME || echo " [FAIL1]" && exit -1
   echo -n " [OK]"
-  $CHMODCMD $CERT o+r $BASE || echo " [FAIL]" && exit -1
+  $CHMODCMD $CERT o+r $BASE || echo " [FAIL2]" && exit -1
   echo " [OK]"
   echo
   echo "*** starting test sequence ***"
@@ -187,14 +187,15 @@ foreach resource ($resources)
   echo " [OK]"
 
   echo -n "copy data node to local filesystem "
-  $CPCMD $CERT $CONTAINER/something.png $THIS_DIR/something.png.2 || echo " [FAIL]" && exit -1
-  cmp $THIS_DIR/something.png $THIS_DIR/something.png.2 || echo " [FAIL]" && exit -1
+
+  $CPCMD $CERT $CONTAINER/something.png $THIS_DIR/something.png.2 || echo " [FAIL1]" && exit -1
+  cmp $THIS_DIR/something.png $THIS_DIR/something.png.2 || echo " [FAIL2]" && exit -1
   \rm -f $THIS_DIR/something.png.2
   echo " [OK]"
 
   echo -n "Check quick copy"
-  $CPCMD $CERT --quick $THIS_DIR/something.png $CONTAINER/something.png.3|| echo " [FAIL]" && exit -1
-  $CPCMD $CERT --quick $CONTAINER/something.png.3 $THIS_DIR/something.png.3 || echo " [FAIL]" && exit -1
+  $CPCMD $CERT --quick $THIS_DIR/something.png $CONTAINER/something.png.3|| echo " [FAIL1]" && exit -1
+  $CPCMD $CERT --quick $CONTAINER/something.png.3 $THIS_DIR/something.png.3 || echo " [FAIL2]" && exit -1
   cmp $THIS_DIR/something.png $THIS_DIR/something.png.3 || echo " [FAIL]" && exit -1
   \rm -f $THIS_DIR/something.png.3
   echo " [OK]"

--- a/vos/test/scripts_old/vospace-link-atest.tcsh
+++ b/vos/test/scripts_old/vospace-link-atest.tcsh
@@ -146,18 +146,6 @@ foreach resource ($resources)
       echo " [OK]"
   endif
 
-  echo -n "copy external link"
-  if ( ${?TESTING_CAVERN} ) then
-      echo " [SKIPPED, vos/issues/83]"
-  else
-      rm -f /tmp/e3link
-      $CPCMD $CERT -L $CONTAINER/e3link /tmp/ >& /dev/null || echo " [FAIL]" && exit -1
-      grep -q google /tmp/e3link || echo " [FAIL]" && exit -1
-      rm -f /tmp/e3link
-      echo " [OK]"
-  endif
-
-
   echo -n "Follow the invalid link and fail"
   $CPCMD $CERT $CONTAINER/e3link/somefile /tmp  >& /dev/null && echo " [FAIL]" && exit -1
   echo " [OK]"

--- a/vos/test/scripts_old/vospace-lock-atest.tcsh
+++ b/vos/test/scripts_old/vospace-lock-atest.tcsh
@@ -133,6 +133,7 @@ foreach resource ($resources)
       $LOCKCMD $CERT $CONTAINER $VUNLOCK_ARGS > /dev/null || echo " [FAIL]" && exit -1
       echo " [OK]"
       echo -n "check unlocked container "
+      echo "$TAGCMD $CERT $CONTAINER $LIST_ARGS"
       $TAGCMD $CERT $CONTAINER $LIST_ARGS | grep -q None && set SUCCESS = "true"
 
       if ( ${SUCCESS} == "true" ) then

--- a/vos/test/scripts_old/vospace-node-properties.tcsh
+++ b/vos/test/scripts_old/vospace-node-properties.tcsh
@@ -120,6 +120,7 @@ foreach resource ($resources)
           echo " [FAIL]" && exit -1
       endif
   else
+      echo "$CHMODCMD $CERT -R g+r $CONTAINER $GROUP1"
       $CHMODCMD $CERT -R g+r $CONTAINER $GROUP1 ||  echo " [FAIL]" && exit -1
       echo -n " verify "
       $LSCMD $CERT $BASE | grep $TIMESTAMP | grep $GROUP1 | grep -q "drw-r-----" || echo " [FAIL]" && exit -1

--- a/vos/vos/commands/vcp.py
+++ b/vos/vos/commands/vcp.py
@@ -140,7 +140,7 @@ def vcp():
         help="DEPRECATED")
     parser.add_argument(
         "--quick", action="store_true",
-        help="assuming CANFAR VOSpace, only comptible with CANFAR VOSpace.",
+        help="DEPRECATED",
         default=False)
     parser.add_argument(
         "-L", "--follow-links",
@@ -169,7 +169,7 @@ def vcp():
 
     client = vos.Client(
         vospace_certfile=args.certfile, vospace_token=args.token,
-        transfer_shortcut=args.quick, insecure=args.insecure)
+        insecure=args.insecure)
 
     if not client.is_remote_file(dest):
         dest = os.path.abspath(dest)

--- a/vos/vos/vos.py
+++ b/vos/vos/vos.py
@@ -2709,7 +2709,6 @@ class Client(object):
             try:
                 property_url = endpoints.recursive_props
             except KeyError as ex:
-                property_url = endpoints.p
                 logger.debug('recursive props endpoint does not exist: {0}'.
                              format(str(ex)))
                 raise Exception('Operation not supported')


### PR DESCRIPTION
Changed `vos` to first try the `files` end point with `PullFromVospace`. That avoids creating a job, a step that now fails when `vault` is in ReadOnly mode.
Also added temporary code to make cutout work with the current VOSpace services.