### PR TITLE
Accept links to external targets (CADC-13802)

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install tox
         run: python -m pip install --upgrade tox
       - name: egg-info vos
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7","3.8","3.9","3.10","3.11","3.12"]
+        python-version: ["3.8","3.9","3.10","3.11","3.12", "3.13"]
         package: [vos]
     steps:
     - name: Checkout code
@@ -54,10 +54,10 @@ jobs:
     needs: tests
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2
       - name: Install tox

--- a/vos/setup.cfg
+++ b/vos/setup.cfg
@@ -52,11 +52,11 @@ edit_on_github = False
 github_project = opencadc/vostools
 install_requires =
     html2text>=2016.5.29
-    cadcutils>=1.5.3
+    cadcutils>=1.5.4
     aenum
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 3.6.1.1
+version = 3.6.2
 
 [options.extras_require]
 test =

--- a/vos/test/scripts_local/vospace-link-atest.tcsh
+++ b/vos/test/scripts_local/vospace-link-atest.tcsh
@@ -137,7 +137,7 @@ foreach resource ($resources)
 
   echo -n "create link to unknown scheme in URI"
   $LNCMD $CERT unknown://cadc.nrc.ca~vault/CADCAuthtest1 $CONTAINER/e2link >& /dev/null && echo " [FAIL]" && exit -1
-  echo " [SKIPPED - TODO]"
+  echo " [OK]"
 
   echo -n "follow the invalid link and fail"
   $CPCMD $CERT $CONTAINER/e2link/somefile /tmp  >& /dev/null && echo " [FAIL]" && exit -1

--- a/vos/test/scripts_local/vospace-link-atest.tcsh
+++ b/vos/test/scripts_local/vospace-link-atest.tcsh
@@ -136,8 +136,7 @@ foreach resource ($resources)
   echo " [OK]"
 
   echo -n "create link to unknown scheme in URI"
-  #TODO not sure why this is not working anymore
-  #$LNCMD $CERT unknown://cadc.nrc.ca~vault/CADCAuthtest1 $CONTAINER/e2link >& /dev/null && echo " [FAIL]" && exit -1
+  $LNCMD $CERT unknown://cadc.nrc.ca~vault/CADCAuthtest1 $CONTAINER/e2link >& /dev/null && echo " [FAIL]" && exit -1
   echo " [SKIPPED - TODO]"
 
   echo -n "follow the invalid link and fail"

--- a/vos/test/scripts_prod/vospace-link-atest.tcsh
+++ b/vos/test/scripts_prod/vospace-link-atest.tcsh
@@ -130,9 +130,8 @@ foreach resource ($resources)
   echo " [OK]"
 
   echo -n "create link to unknown scheme in URI"
-  #TODO not sure why this is not working anymore
-  #$LNCMD $CERT unknown://cadc.nrc.ca~vault/CADCRegtest1 $CONTAINER/e2link >& /dev/null && echo " [FAIL]" && exit -1
-  echo " [SKIPPED - TODO]"
+  $LNCMD $CERT file:///cadc.nrc.ca~vault/CADCRegtest1 $CONTAINER/e2link >& /dev/null || echo " [FAIL]" && exit -1
+  echo " [OK]"
 
   echo -n "follow the invalid link and fail"
   $CPCMD $CERT $CONTAINER/e2link/somefile /tmp  >& /dev/null && echo " [FAIL]" && exit -1

--- a/vos/tox.ini
+++ b/vos/tox.ini
@@ -5,7 +5,7 @@ name = vos
 
 [tox]
 envlist =
-    py{37,38,39,310,311,312}
+    py{38,39,310,311,312,313}
 requires =
     pip >= 19.3.1
 

--- a/vos/vos/commands/vln.py
+++ b/vos/vos/commands/vln.py
@@ -2,7 +2,7 @@
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 #
-#  (c) 2024.                            (c) 2024.
+#  (c) 2025.                            (c) 2025.
 #  Government of Canada                 Gouvernement du Canada
 #  National Research Council            Conseil national de recherches
 #  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6

--- a/vos/vos/commands/vln.py
+++ b/vos/vos/commands/vln.py
@@ -2,7 +2,7 @@
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 #
-#  (c) 2022.                            (c) 2022.
+#  (c) 2024.                            (c) 2024.
 #  Government of Canada                 Gouvernement du Canada
 #  National Research Council            Conseil national de recherches
 #  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -89,7 +89,8 @@ examples:
 
     vln vos:vospace/junk.txt vos:vospace/linkToJunk.txt
     vln vos:vospace/directory vos:vospace/linkToDirectory
-    vln http://external.data.source vos:vospace/linkToExternalDataSource
+    vln https://external.data.source vos:vospace/linkToExternalDataSource
+    vln file:///data/localfile vos:vospace/linkToLocalFile
 
 """.format(URI_DESCRIPTION)
 
@@ -106,11 +107,10 @@ def vln():
             vospace_certfile=opt.certfile,
             vospace_token=opt.token,
             insecure=opt.insecure)
-        if not client.is_remote_file(opt.source) or \
-                not client.is_remote_file(opt.target):
+        if not client.is_remote_file(opt.target):
             raise ArgumentError(
                 None,
-                "source must be vos node or http url, target must be vos node")
+                "source must be vos node or https url, target must be vos node")
 
         client.link(opt.source, opt.target)
     except ArgumentError as ex:

--- a/vos/vos/commands/vln.py
+++ b/vos/vos/commands/vln.py
@@ -110,7 +110,7 @@ def vln():
         if not client.is_remote_file(opt.target):
             raise ArgumentError(
                 None,
-                "source must be vos node or https url, target must be vos node")
+                "target must be vos node")
 
         client.link(opt.source, opt.target)
     except ArgumentError as ex:

--- a/vos/vos/vos.py
+++ b/vos/vos/vos.py
@@ -2,7 +2,7 @@
 # ******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 # *************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 #
-#  (c) 2024.                            (c) 2024.
+#  (c) 2025.                            (c) 2025.
 #  Government of Canada                 Gouvernement du Canada
 #  National Research Council            Conseil national de recherches
 #  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6

--- a/vos/vos/vos.py
+++ b/vos/vos/vos.py
@@ -2723,19 +2723,23 @@ class Client(object):
 
     def listdir(self, uri, force=False):
         """
-        Walk through the directory structure a la os.walk.
-        Setting force=True will make sure no cached results are used.
+        Return a list with the content of the directory
         Follows LinksNodes to their destination location.
         Note: this method returns a list of children names. For larger
-        directories, use get_children_info() to iterate through the list and
-        avoid loading it into memory.
+        directories, use get_children_info() to iterate through it and
+        avoid loading the entire content into memory.
 
         :param force: don't use cached values, retrieve from service.
         :param uri: The ContainerNode to get a listing of.
         :rtype [unicode]
         """
         logger.debug(str(uri))
-        return [i.name for i in self.get_children_info(uri, force=force)]
+        node = self.get_node(uri, limit=0, force=force)
+        while node.type == "vos:LinkNode":
+            uri = node.target
+            # logger.debug(uri)
+            node = self.get_node(uri, limit=0, force=force)
+        return [i.name for i in self.get_children_info(node.uri, force=force)]
 
     def _node_type(self, uri):
         """

--- a/vos/vos/vos.py
+++ b/vos/vos/vos.py
@@ -811,7 +811,7 @@ class Node(object):
         """ Gets an iterator over the nodes held to by a ContainerNode"""
         # IF THE CALLER KNOWS THEY DON'T NEED THE CHILDREN THEY
         # CAN SET LIMIT=0 IN THE CALL Also, if the number of nodes
-        # on the firt call was less than 500, we likely got them
+        # on the first call was less than 500, we likely got them
         # all during the init
         if not self.isdir():
             return
@@ -1890,7 +1890,7 @@ class Client(object):
                     # purposes:
                     #   1. Check if source is identical to destination and
                     #   avoid sending the bytes again.
-                    #   2. send info to the service so it can recover in case
+                    #   2. send info to the service so that it can recover in case
                     #   the bytes got corrupted on the way
                     src_md5 = md5_cache.MD5Cache.compute_md5(source)
                     if src_md5 == dest_node_md5:
@@ -2186,8 +2186,7 @@ class Client(object):
     def link(self, src_uri, link_uri):
         """Make link_uri point to src_uri.
 
-        :param src_uri: the existing resource, either a vospace uri or a http
-        url
+        :param src_uri: the existing resource to link to
         :type src_uri: unicode
         :param link_uri: the vospace node to create that will be a link to
         src_uri
@@ -2197,7 +2196,8 @@ class Client(object):
         HttpException exceptions declared in the cadcutils.exceptions module
         """
         link_uri = self.fix_uri(link_uri)
-        src_uri = self.fix_uri(src_uri)
+        if "://" not in src_uri:
+            src_uri = self.fix_uri(src_uri)
 
         # if the link_uri points at an existing directory then we try and
         # make a link into that directory
@@ -2726,21 +2726,16 @@ class Client(object):
         Walk through the directory structure a la os.walk.
         Setting force=True will make sure no cached results are used.
         Follows LinksNodes to their destination location.
+        Note: this method returns a list of children names. For larger
+        directories, use get_children_info() to iterate through the list and
+        avoid loading it into memory.
 
         :param force: don't use cached values, retrieve from service.
         :param uri: The ContainerNode to get a listing of.
         :rtype [unicode]
         """
-        names = []
         logger.debug(str(uri))
-        node = self.get_node(uri, limit=None, force=force)
-        while node.type == "vos:LinkNode":
-            uri = node.target
-            # logger.debug(uri)
-            node = self.get_node(uri, limit=None, force=force)
-        for thisNode in node.node_list:
-            names.append(thisNode.name)
-        return names
+        return [i.name for i in self.get_children_info(uri, force=force)]
 
     def _node_type(self, uri):
         """


### PR DESCRIPTION
+ fix for `listdir` to work with larger directories that used to require pagination but can use iterator now (#228 ).

Also updated the supported Python versions.