### PR TITLE
fix get children yield node

### DIFF
--- a/vos/vos/vos.py
+++ b/vos/vos/vos.py
@@ -819,7 +819,7 @@ class Node(object):
         if self.node_list is not None:
             # children already downloaded
             for i in self.node_list:
-                yield i.uri
+                yield i
 
         # stream children
         xml_file = StringIO(


### PR DESCRIPTION
**Description:**

This PR addresses a bug in the get_children method of the Node class in the vos library. Previously, the method was yielding only the uri string of each child node, which caused issues when the calling code expected full Node objects with attributes such as .name.

**Changes made:**

Updated get_children to yield complete Node instances instead of just their uri strings.
This fix ensures compatibility with code that iterates over children nodes and accesses their properties.

**Impact:**

Fixes AttributeError when accessing attributes on children nodes.
Improves usability and consistency of the vos library API.

**Tests:**

Automated tests have been run against the updated code and all pass successfully.

**Issue**
#231 (comment)

Please review and consider merging this change. Thanks!