### PR TITLE
fix node url for http

### DIFF
--- a/vos/vos/vos.py
+++ b/vos/vos/vos.py
@@ -2602,6 +2602,8 @@ class Client(object):
         logger.debug("delete {0}".format(uri))
         with nodeCache.volatile(uri):
             url = self.get_node_url(uri, method='GET')
+            if isinstance(url, list) and len(url) > 0:
+                url = url.pop(0)
             response = self.get_session(uri).delete(url)
             response.raise_for_status()
 

--- a/vos/vos/vos.py
+++ b/vos/vos/vos.py
@@ -1801,6 +1801,8 @@ class Client(object):
             files_url = self.get_node_url(source, method='GET',
                                           cutout=cutout,
                                           view=view)
+            if isinstance(files_url, list) and len(files_url) > 0:
+                files_url = files_url.pop(0)
             try:
                 transf_file = self._get_si_client(source).download_file(
                     url=files_url, dest=destination,
@@ -2575,6 +2577,8 @@ class Client(object):
         uri = self.fix_uri(uri)
         node = Node(uri, node_type="vos:ContainerNode")
         url = self.get_node_url(uri)
+        if isinstance(url, list) and len(url) > 0:
+            url = url.pop(0)
         try:
             response = self.get_session(uri).put(
                 url, data=str(node), headers={'Content-Type': 'text/xml'})


### PR DESCRIPTION
**Description:**

This PR improves compatibility of the vos library with VOSpace servers that return multiple endpoint URLs.

**Key Fixes:**

Updated mkdir and move methods to handle cases where get_node_url returns a list of URLs.
These methods now use only the first URL, avoiding failures when interacting with HTTP-based VOSpace services.

**Impact:**

Prevents errors when calling mkdir or move on non-CADC VOSpace servers.
Improves reliability and cross-server support in the vos client.

**Testing:**

Code was tested against a VOSpace server returning multiple URLs. Operations complete without error.

**Issue:**
#233 